### PR TITLE
Enhance Wild Draw 4 restriction to check both color and value

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -107,12 +107,22 @@ function playCard(gameState, playerIndex, cardIndex) {
   
   // We no longer use implicit color choice
   
-  // Check if card can be played
-  if (!canPlayCard(card, topDiscard, gameState.currentColor)) {
+  // Check if card can be played (pass the player's hand for Wild Draw 4 validation)
+  if (!canPlayCard(card, topDiscard, gameState.currentColor, player.hand)) {
     // If human player tries to play an invalid card, trigger shake animation
     if (playerIndex === 0) {
-      // This will be handled in the UI layer
-      window.dispatchEvent(new CustomEvent('invalidCardPlay', { detail: { cardIndex } }));
+      // For Wild Draw 4, provide specific feedback if player has matching color cards
+      if (card.value === 'Wild Draw 4') {
+        window.dispatchEvent(new CustomEvent('invalidCardPlay', { 
+          detail: { 
+            cardIndex, 
+            message: "You can't play Wild Draw 4 when you have cards matching the current color!" 
+          } 
+        }));
+      } else {
+        // This will be handled in the UI layer
+        window.dispatchEvent(new CustomEvent('invalidCardPlay', { detail: { cardIndex } }));
+      }
     }
     return; // Exit early, don't proceed with card play
   }
@@ -175,9 +185,26 @@ function playCard(gameState, playerIndex, cardIndex) {
 }
 
 // Check if a card can be played
-function canPlayCard(card, topDiscard, currentColor) {
-  // Wild cards can always be played
-  if (card.value === 'Wild' || card.value === 'Wild Draw 4') {
+function canPlayCard(card, topDiscard, currentColor, playerHand) {
+  // Regular Wild cards can always be played
+  if (card.value === 'Wild') {
+    return true;
+  }
+  
+  // Wild Draw 4 can only be played if the player has no cards matching the current color
+  if (card.value === 'Wild Draw 4') {
+    // If playerHand is provided (for validation), check if player has matching color cards
+    if (playerHand) {
+      // Check if player has any cards matching the current color
+      const hasMatchingColorCard = playerHand.some(handCard => 
+        handCard !== card && handCard.color === currentColor
+      );
+      
+      // Wild Draw 4 can only be played if player has no matching color cards
+      return !hasMatchingColorCard;
+    }
+    
+    // If no hand is provided (backward compatibility), allow the play
     return true;
   }
   
@@ -452,7 +479,7 @@ function playerHasLegalMoves(playerIndex) {
   
   // Check each card in hand to see if any can be played
   for (let i = 0; i < player.hand.length; i++) {
-    if (canPlayCard(player.hand[i], topDiscard, gameState.currentColor)) {
+    if (canPlayCard(player.hand[i], topDiscard, gameState.currentColor, player.hand)) {
       return true;
     }
   }
@@ -526,7 +553,8 @@ function drawCard() {
     
     // Only move to next player's turn if the drawn card can't be played
     const topDiscard = gameState.discardPile[gameState.discardPile.length - 1];
-    if (!canPlayCard(drawnCard, topDiscard, gameState.currentColor)) {
+    const player = gameState.players[gameState.currentPlayerIndex];
+    if (!canPlayCard(drawnCard, topDiscard, gameState.currentColor, player.hand)) {
       // Move to next player's turn
       nextTurn();
       
@@ -550,7 +578,7 @@ function playAITurn() {
   // Look for a card to play
   for (let i = 0; i < player.hand.length; i++) {
     const card = player.hand[i];
-    if (canPlayCard(card, topDiscard, gameState.currentColor)) {
+    if (canPlayCard(card, topDiscard, gameState.currentColor, player.hand)) {
       // Play the card
       setTimeout(() => playCard(gameState, gameState.currentPlayerIndex, i), 500);
       return;
@@ -561,7 +589,7 @@ function playAITurn() {
   const drawnCard = drawSingleCard(gameState.currentPlayerIndex);
   
   // Check if drawn card can be played
-  if (canPlayCard(drawnCard, topDiscard, gameState.currentColor)) {
+  if (canPlayCard(drawnCard, topDiscard, gameState.currentColor, player.hand)) {
     // Play the card
     setTimeout(() => playCard(gameState, gameState.currentPlayerIndex, player.hand.length - 1), 500);
   } else {

--- a/src/game.js
+++ b/src/game.js
@@ -111,12 +111,12 @@ function playCard(gameState, playerIndex, cardIndex) {
   if (!canPlayCard(card, topDiscard, gameState.currentColor, player.hand)) {
     // If human player tries to play an invalid card, trigger shake animation
     if (playerIndex === 0) {
-      // For Wild Draw 4, provide specific feedback if player has matching color cards
+      // For Wild Draw 4, provide specific feedback if player has playable cards
       if (card.value === 'Wild Draw 4') {
         window.dispatchEvent(new CustomEvent('invalidCardPlay', { 
           detail: { 
             cardIndex, 
-            message: "You can't play Wild Draw 4 when you have cards matching the current color!" 
+            message: "You can't play Wild Draw 4 when you have cards matching the current color or value!" 
           } 
         }));
       } else {
@@ -191,20 +191,23 @@ function canPlayCard(card, topDiscard, currentColor, playerHand) {
     return true;
   }
   
-  // Wild Draw 4 can only be played if the player has no cards matching the current color
+  // Wild Draw 4 can only be played if the player has no cards matching the current color or value
   if (card.value === 'Wild Draw 4') {
-    // If playerHand is provided (for validation), check if player has matching color cards
-    if (playerHand) {
-      // Check if player has any cards matching the current color
-      const hasMatchingColorCard = playerHand.some(handCard => 
-        handCard !== card && handCard.color === currentColor
+    // If playerHand is provided (for validation), check if player has playable cards
+    if (playerHand && topDiscard) {
+      // Check if player has any cards matching the current color or the value of the top card
+      const hasPlayableCard = playerHand.some(handCard => 
+        handCard !== card && (
+          handCard.color === currentColor || // Matching color
+          (handCard.value === topDiscard.value && handCard.value !== 'Wild' && handCard.value !== 'Wild Draw 4') // Matching value (excluding wilds)
+        )
       );
       
-      // Wild Draw 4 can only be played if player has no matching color cards
-      return !hasMatchingColorCard;
+      // Wild Draw 4 can only be played if player has no playable cards
+      return !hasPlayableCard;
     }
     
-    // If no hand is provided (backward compatibility), allow the play
+    // If no hand is provided or no top discard (backward compatibility), allow the play
     return true;
   }
   

--- a/src/ui.js
+++ b/src/ui.js
@@ -1608,6 +1608,7 @@ window.addEventListener('DOMContentLoaded', () => {
   window.addEventListener('invalidCardPlay', (event) => {
     // Get the card index from the event
     const cardIndex = event.detail.cardIndex;
+    const errorMessage = event.detail.message;
     
     // Find the card element in the player's hand
     const playerHand = document.getElementById('player-hand');
@@ -1618,6 +1619,11 @@ window.addEventListener('DOMContentLoaded', () => {
       // Add shake animation
       const cardElement = cardElements[cardIndex];
       cardElement.classList.add('shake');
+      
+      // Show error message if provided (specifically for Wild Draw 4 restriction)
+      if (errorMessage) {
+        showErrorMessage(errorMessage);
+      }
       
       // Remove the shake class after animation completes
       setTimeout(() => {
@@ -1641,12 +1647,51 @@ window.addEventListener('DOMContentLoaded', () => {
       }, 500);
     }
   });
+  
 });
+
+// Function to show an error message to the player
+function showErrorMessage(message) {
+  // Create or get the error message container
+  let errorContainer = document.getElementById('error-message-container');
+  
+  if (!errorContainer) {
+    errorContainer = document.createElement('div');
+    errorContainer.id = 'error-message-container';
+    applyStyles(errorContainer, {
+      position: 'fixed',
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+      backgroundColor: 'rgba(255, 0, 0, 0.8)',
+      color: 'white',
+      padding: '15px',
+      borderRadius: '8px',
+      maxWidth: '80%',
+      textAlign: 'center',
+      zIndex: '1000',
+      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
+      fontSize: '20px',
+      fontWeight: 'bold'
+    });
+    document.body.appendChild(errorContainer);
+  }
+  
+  // Set the message
+  errorContainer.textContent = message;
+  
+  // Show and then hide after a delay
+  errorContainer.style.display = 'block';
+  setTimeout(() => {
+    errorContainer.style.display = 'none';
+  }, 3000);
+}
 
 export {
   renderGame,
   updateGameDisplay,
   showWelcomeScreen,
   renderBingo,
-  renderDad
+  renderDad,
+  showErrorMessage
 };


### PR DESCRIPTION
## Summary
- Enhanced the Wild Draw 4 restriction to check for both matching color AND matching value cards
- A player can only play a Wild Draw 4 if they have no playable cards (no cards matching current color or value)
- Updated error message to inform players about both color and value restrictions
- This creates a more challenging and strategic gameplay experience

## Test plan
- Try to play a Wild Draw 4 when you have a card matching the current color - it should be rejected
- Try to play a Wild Draw 4 when you have a card with the same value as the top card - it should also be rejected
- Verify you can still play Wild Draw 4 when you have no matching color or value cards
- Check that AI players follow the same rules

Builds on PR #7, fixes #5 with additional restrictions

🤖 Generated with [Claude Code](https://claude.ai/code)