### PR TITLE
Fix deck click handler for drawing required cards

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -281,6 +281,15 @@ function handleDrawCards(numCards) {
     // Set the drawing cards flag to indicate the player must draw cards
     gameState.isDrawingCards = true;
     
+    // Temporarily set the current player index to the human player to allow drawing
+    // This is necessary because the drawCard function checks if it's the player's turn
+    if (gameState.currentPlayerIndex !== 0) {
+      // Remember the actual current player index to restore it later
+      gameState.pendingDrawPlayerIndex = gameState.currentPlayerIndex;
+      // Temporarily set current player to human player
+      gameState.currentPlayerIndex = 0;
+    }
+    
     // Update the UI to show the drawing state
     updateGameDisplay(gameState);
     
@@ -558,6 +567,12 @@ function handleRequiredDraw() {
     // Show a message indicating all required cards have been drawn
     window.dispatchEvent(new CustomEvent('drawRequirementComplete'));
     
+    // Restore the original player index if we temporarily changed it
+    if (gameState.pendingDrawPlayerIndex !== null) {
+      gameState.currentPlayerIndex = gameState.pendingDrawPlayerIndex;
+      gameState.pendingDrawPlayerIndex = null;
+    }
+    
     // Move to next player's turn
     nextTurn();
     
@@ -577,7 +592,14 @@ function handleRequiredDraw() {
 
 // Player draws a card
 function drawCard() {
-  if (gameState.currentPlayerIndex !== 0) return; // Only human player can use this function
+  // Always allow drawing if the player has required draws
+  if (gameState.requiredDraws > 0) {
+    // This is fine, we want to allow drawing when required
+  } else if (gameState.currentPlayerIndex !== 0) {
+    // Otherwise only human player can use this function when it's their turn
+    return;
+  }
+  
   if (gameState.waitingForColorChoice) return; // Don't draw if waiting for color choice
   
   // Check if player has legal moves and there are no required draws

--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,13 @@
   font-style: normal;
 }
 
+/* Animation for draw indicator */
+@keyframes pulse {
+  0% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.1); opacity: 0.8; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
 html, body {
   width: 100%;
   height: 100%;

--- a/src/ui.js
+++ b/src/ui.js
@@ -466,6 +466,26 @@ function renderDeckAndDiscardPile() {
   const deckBack = document.createElement('div');
   deckBack.className = 'card-back';
   deckBack.style.width = '120px';
+  
+  // Add a visual indicator if a player needs to draw cards
+  if (gameState.isDrawingCards && gameState.requiredDraws > 0) {
+    const drawIndicator = document.createElement('div');
+    drawIndicator.className = 'draw-indicator';
+    drawIndicator.textContent = `Draw ${gameState.requiredDraws} more`;
+    drawIndicator.style.position = 'absolute';
+    drawIndicator.style.top = '-30px';
+    drawIndicator.style.left = '0';
+    drawIndicator.style.width = '100%';
+    drawIndicator.style.padding = '5px';
+    drawIndicator.style.backgroundColor = 'rgba(255, 0, 0, 0.8)';
+    drawIndicator.style.color = 'white';
+    drawIndicator.style.borderRadius = '5px';
+    drawIndicator.style.textAlign = 'center';
+    drawIndicator.style.fontWeight = 'bold';
+    drawIndicator.style.zIndex = '10';
+    drawIndicator.style.animation = 'pulse 1s infinite';
+    deckBack.appendChild(drawIndicator);
+  }
   deckBack.style.height = '168px';
   deckBack.style.borderRadius = '10px';
   deckBack.style.backgroundColor = '#ff5757';
@@ -1686,6 +1706,23 @@ function showErrorMessage(message) {
     errorContainer.style.display = 'none';
   }, 3000);
 }
+
+// Function to show a draw requirement message
+function showDrawRequirementMessage(numCards) {
+  // Create a message about drawing cards
+  const message = `You need to draw ${numCards} cards!`;
+  showErrorMessage(message);
+}
+
+// Add event listeners for drawing requirements
+window.addEventListener('showDrawRequirement', (event) => {
+  const numCards = event.detail.numCards;
+  showDrawRequirementMessage(numCards);
+});
+
+window.addEventListener('drawRequirementComplete', () => {
+  showErrorMessage('All required cards drawn! Next player\'s turn.');
+});
 
 export {
   renderGame,

--- a/src/ui.js
+++ b/src/ui.js
@@ -531,10 +531,13 @@ function renderDeckAndDiscardPile() {
   
   // Add click handler for drawing cards
   deckElement.onclick = () => {
-    if (gameState.currentPlayerIndex === 0) { // Only if it's the human player's turn
+    // Allow drawing when it's either:
+    // 1. The player's turn, OR
+    // 2. The player has required draws to make (from Draw 2 or Draw 4)
+    if (gameState.currentPlayerIndex === 0 || gameState.isDrawingCards) {
       if (gameState.requiredDraws > 0) {
         // If player needs to draw cards due to Draw 2 or Draw 4
-        drawCard(gameState);
+        drawCard();
         
         // Remove 'required-draw' and 'active-deck' classes when no more draws required
         if (gameState.requiredDraws === 0) {
@@ -544,7 +547,9 @@ function renderDeckAndDiscardPile() {
           // Remove any draw indicators
           const drawIndicators = document.querySelectorAll('.draw-indicator, .deck-reminder');
           drawIndicators.forEach(indicator => {
-            indicator.parentElement.removeChild(indicator);
+            if (indicator.parentElement) {
+              indicator.parentElement.removeChild(indicator);
+            }
           });
         }
       } else if (!gameState.waitingForColorChoice) {


### PR DESCRIPTION
## Summary
- Fixed critical issue where clicking on the deck did nothing when required to draw cards after an opponent plays Draw 2/Draw 4
- Made the drawing mechanism work correctly in all scenarios

## Problem
When an opponent (e.g., Dad) played a Draw 2 or Wild Draw 4 card:
1. The game showed a message that cards needed to be drawn
2. But clicking on the deck had no effect
3. This blocked gameplay since the user couldn't progress

## Solution
1. Modified deck click handler to work even when it's not the player's turn but they need to draw cards
2. Fixed the drawCard function to always allow drawing when requiredDraws > 0
3. Added proper player index management to handle required draws correctly
4. Ensured correct restoration of game state after all required cards are drawn

## Test Plan
- When an opponent plays a Draw 2 card, clicking on the deck now successfully draws cards
- When an opponent plays a Wild Draw 4 card, clicking on the deck now successfully draws cards
- After drawing all required cards, gameplay correctly advances to the next player's turn

Fixes the click issue mentioned in #9

🤖 Generated with [Claude Code](https://claude.ai/code)