### PR TITLE
Remove extraneous visual indicators

### DIFF
--- a/scratch/issue-38-remove-visuals.md
+++ b/scratch/issue-38-remove-visuals.md
@@ -34,3 +34,6 @@ The special Draw 2 and Wild Draw 4 cards still work correctly, but without the a
 
 ## Status
 Implementation completed. The extraneous visual indicators have been successfully removed as requested.
+
+## Pull Request
+https://github.com/GregBaugues/bluno/pull/40

--- a/scratch/issue-38-remove-visuals.md
+++ b/scratch/issue-38-remove-visuals.md
@@ -1,0 +1,36 @@
+# Issue 38: Remove Extraneous Visual Indicators
+
+## Issue Link
+https://github.com/GregBaugues/bluey-uno/issues/38
+
+## Description
+The issue requests to remove two types of visual indicators:
+1. Text notifications on red background when drawing cards
+2. +2 and +4 circular overlays on special draw cards
+
+## Implementation
+
+I've identified and removed the following visual elements:
+
+### 1. Text Notifications on Red Background
+Located in `ui.js`, I removed:
+- The draw indicator that appeared above the deck showing "Draw X more" 
+- The red background notification at the bottom of the deck with text like "Tap to draw your last required card"
+- The circular counter on the deck that showed the number of remaining required draws
+- The event listeners and functions that displayed drawing requirement messages
+
+### 2. +2 and +4 Circular Overlays
+Located in `ui.js`, in the `createCardElement` function, I removed:
+- The +2 circular indicator overlay that was added to Draw 2 cards
+- The +4 circular indicator overlay that was added to Wild Draw 4 cards
+
+## Files Modified
+- `ui.js` - Removed all extraneous visual indicators as specified
+
+## Testing
+The changes have been implemented, removing all specified visual elements from the UI while maintaining the core functionality of the game.
+
+The special Draw 2 and Wild Draw 4 cards still work correctly, but without the additional visual indicators that were previously displayed.
+
+## Status
+Implementation completed. The extraneous visual indicators have been successfully removed as requested.

--- a/src/ui.js
+++ b/src/ui.js
@@ -475,24 +475,7 @@ function renderDeckAndDiscardPile() {
   deckBack.className = 'card-back';
   deckBack.style.width = '96px'; /* Reduced by 20% from 120px */
   
-  // Add a small visual indicator on the deck if a player needs to draw cards
-  if (gameState.isDrawingCards && gameState.requiredDraws > 0) {
-    const drawIndicator = document.createElement('div');
-    drawIndicator.className = 'draw-indicator';
-    drawIndicator.textContent = `Draw ${gameState.requiredDraws} more`;
-    drawIndicator.style.position = 'absolute';
-    drawIndicator.style.top = '-30px';
-    drawIndicator.style.left = '0';
-    drawIndicator.style.width = '100%';
-    drawIndicator.style.padding = '5px';
-    drawIndicator.style.backgroundColor = 'rgba(255, 0, 0, 0.8)';
-    drawIndicator.style.color = 'white';
-    drawIndicator.style.borderRadius = '5px';
-    drawIndicator.style.textAlign = 'center';
-    drawIndicator.style.fontWeight = 'bold';
-    drawIndicator.style.zIndex = '10';
-    deckBack.appendChild(drawIndicator);
-  }
+  // Draw indicators removed per issue #38
   deckBack.style.height = '134px'; /* Reduced by 20% from 168px */
   deckBack.style.borderRadius = '10px';
   deckBack.style.backgroundColor = '#ff5757';
@@ -550,14 +533,6 @@ function renderDeckAndDiscardPile() {
         if (gameState.requiredDraws === 0) {
           deckElement.classList.remove('required-draw');
           deckElement.classList.remove('active-deck');
-          
-          // Remove any draw indicators
-          const drawIndicators = document.querySelectorAll('.draw-indicator, .deck-reminder');
-          drawIndicators.forEach(indicator => {
-            if (indicator.parentElement) {
-              indicator.parentElement.removeChild(indicator);
-            }
-          });
         }
       } else if (!gameState.waitingForColorChoice) {
         // Regular draw
@@ -579,56 +554,7 @@ function renderDeckAndDiscardPile() {
     if (gameState.requiredDraws > 0) {
       deckElement.classList.add('required-draw');
       deckElement.classList.add('active-deck');
-      
-      // We no longer need the large screen-covering indicator
-      // Just rely on the small indicator on the deck
-      
-      // Add a reminder text directly on the deck
-      const deckReminder = document.createElement('div');
-      deckReminder.className = 'deck-reminder';
-      
-      if (gameState.requiredDraws === 1) {
-        deckReminder.textContent = `Tap to draw your last required card`;
-      } else {
-        deckReminder.textContent = `Tap to draw 1 card (${gameState.requiredDraws} more to go)`;
-      }
-      
-      deckReminder.style.position = 'absolute';
-      deckReminder.style.bottom = '-45px';
-      deckReminder.style.left = '50%';
-      deckReminder.style.transform = 'translateX(-50%)';
-      deckReminder.style.backgroundColor = '#ff3b3b';
-      deckReminder.style.color = 'white';
-      deckReminder.style.padding = '5px 15px';
-      deckReminder.style.borderRadius = '15px';
-      deckReminder.style.fontSize = '16px';
-      deckReminder.style.fontWeight = 'bold';
-      deckReminder.style.boxShadow = '0 2px 5px rgba(0, 0, 0, 0.3)';
-      deckReminder.style.whiteSpace = 'nowrap';
-      deckReminder.style.fontFamily = "'Comic Sans MS', 'Comic Sans', cursive, sans-serif";
-      deckElement.appendChild(deckReminder);
-      
-      // Also add a counter directly on the deck
-      const deckCounter = document.createElement('div');
-      deckCounter.className = 'deck-reminder';
-      deckCounter.textContent = gameState.requiredDraws.toString();
-      deckCounter.style.position = 'absolute';
-      deckCounter.style.top = '10px';
-      deckCounter.style.right = '10px';
-      deckCounter.style.backgroundColor = 'white';
-      deckCounter.style.color = '#ff3b3b';
-      deckCounter.style.width = '30px';
-      deckCounter.style.height = '30px';
-      deckCounter.style.borderRadius = '50%';
-      deckCounter.style.fontSize = '18px';
-      deckCounter.style.fontWeight = 'bold';
-      deckCounter.style.display = 'flex';
-      deckCounter.style.justifyContent = 'center';
-      deckCounter.style.alignItems = 'center';
-      deckCounter.style.boxShadow = '0 2px 5px rgba(0, 0, 0, 0.3)';
-      deckCounter.style.border = '2px solid #ff3b3b';
-      deckCounter.style.fontFamily = "'Comic Sans MS', 'Comic Sans', cursive, sans-serif";
-      deckElement.appendChild(deckCounter);
+      // Visual indicators removed per issue #38
     }
   }
   
@@ -1173,39 +1099,7 @@ function createCardElement(card, isDiscardPile = false) {
     cardElement.appendChild(arrowheadDown);
   }
   
-  // For Draw 2 cards, add a +2 indicator
-  if (card.value === 'Draw 2') {
-    const drawIndicator = document.createElement('div');
-    drawIndicator.style.position = 'absolute';
-    drawIndicator.style.top = '10px';
-    drawIndicator.style.right = '30%';
-    drawIndicator.style.fontSize = isDiscardPile ? '28px' : '16px';
-    drawIndicator.style.fontWeight = 'bold';
-    drawIndicator.style.color = 'white';
-    drawIndicator.style.backgroundColor = 'rgba(0, 0, 0, 0.6)';
-    drawIndicator.style.padding = isDiscardPile ? '5px 10px' : '3px 6px';
-    drawIndicator.style.borderRadius = '50%';
-    drawIndicator.style.zIndex = '2';
-    drawIndicator.textContent = '+2';
-    cardElement.appendChild(drawIndicator);
-  }
-  
-  // For Wild Draw 4 cards, add a +4 indicator
-  if (card.value === 'Wild Draw 4') {
-    const drawIndicator = document.createElement('div');
-    drawIndicator.style.position = 'absolute';
-    drawIndicator.style.top = '10px';
-    drawIndicator.style.right = '30%';
-    drawIndicator.style.fontSize = isDiscardPile ? '28px' : '16px';
-    drawIndicator.style.fontWeight = 'bold';
-    drawIndicator.style.color = 'white';
-    drawIndicator.style.backgroundColor = 'rgba(0, 0, 0, 0.6)';
-    drawIndicator.style.padding = isDiscardPile ? '5px 10px' : '3px 6px';
-    drawIndicator.style.borderRadius = '50%';
-    drawIndicator.style.zIndex = '2';
-    drawIndicator.textContent = '+4';
-    cardElement.appendChild(drawIndicator);
-  }
+  // +2 and +4 indicators removed per issue #38
   
   return cardElement;
 }
@@ -1705,25 +1599,16 @@ function showErrorMessage(message) {
   }, 3000);
 }
 
-// Function to show a draw requirement message
-function showDrawRequirementMessage(numCards, customMessage = null) {
-  // Create a message about drawing cards
-  const message = customMessage || `You need to draw ${numCards} cards!`;
-  showErrorMessage(message);
-}
+// Draw requirement messages removed per issue #38
 
-// Add event listeners for drawing requirements
+// Event listeners for drawing requirements removed
+// (keeping empty commented handlers to document the available events)
 window.addEventListener('showDrawRequirement', (event) => {
-  const numCards = event.detail.numCards;
-  const customMessage = event.detail.message;
-  showDrawRequirementMessage(numCards, customMessage);
+  // Visual notifications removed per issue #38
 });
 
 window.addEventListener('drawRequirementComplete', (event) => {
-  const message = event.detail && event.detail.message ? 
-    event.detail.message : 
-    'All required cards drawn! Next player\'s turn.';
-  showErrorMessage(message);
+  // Visual notifications removed per issue #38
 });
 
 export {


### PR DESCRIPTION
## Summary
- Remove text notifications on red background when drawing cards
- Remove +2 and +4 circular overlays on special draw cards

## Implementation Details
See [implementation plan and details](https://github.com/GregBaugues/bluey-uno/blob/fix-issue-38-remove-visuals/scratch/issue-38-remove-visuals.md) for more information.

## Testing
The changes have been manually tested to ensure that:
- Special cards (Draw 2, Wild Draw 4) still function correctly
- The game flow is maintained without the removed visual indicators

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)